### PR TITLE
Fix code scanning alert no. 4: Incomplete URL substring sanitization

### DIFF
--- a/toml_cfg_tool/src/updates_toml.py
+++ b/toml_cfg_tool/src/updates_toml.py
@@ -1,13 +1,15 @@
 # ./toml_cfg_tool/src/updates_toml.py 
 import toml 
 from toml_cfg_tool.src.bkup import backup_file
+from urllib.parse import urlparse
 from toml_cfg_tool.src.color_codes import BOLD, CYAN, ORANGE
 from toml_cfg_tool.src.print_colors import print_two_colors
 
 
 def update_pyproject_toml(file_path, repo_url, updates, dry_run=False, backup=False):
     
-    if "github.com" in repo_url:
+    parsed_url = urlparse(repo_url)
+    if parsed_url.hostname and parsed_url.hostname.endswith("github.com"):
         config = toml.load(file_path)
         config['project']['urls']['Homepage'] = repo_url
         with open(file_path, 'w') as f:


### PR DESCRIPTION
Fixes [https://github.com/VinnyVanGogh/toml_cfg_tool/security/code-scanning/4](https://github.com/VinnyVanGogh/toml_cfg_tool/security/code-scanning/4)

To fix the problem, we need to replace the substring check with a more robust method that parses the URL and checks the hostname. This ensures that the URL genuinely belongs to the intended domain. Specifically, we will:
1. Import the `urlparse` function from the `urllib.parse` module.
2. Parse the `repo_url` to extract the hostname.
3. Check if the hostname ends with `github.com`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
