### PR TITLE
Fix code scanning alert no. 5: Incomplete URL substring sanitization

### DIFF
--- a/toml_cfg_tool/src/updates_toml.py
+++ b/toml_cfg_tool/src/updates_toml.py
@@ -9,7 +9,8 @@ from toml_cfg_tool.src.print_colors import print_two_colors
 def update_pyproject_toml(file_path, repo_url, updates, dry_run=False, backup=False):
     
     parsed_url = urlparse(repo_url)
-    if parsed_url.hostname and parsed_url.hostname.endswith("github.com"):
+    hostname = parsed_url.hostname
+    if hostname and (hostname == "github.com" or hostname.endswith(".github.com")):
         config = toml.load(file_path)
         config['project']['urls']['Homepage'] = repo_url
         with open(file_path, 'w') as f:


### PR DESCRIPTION
Fixes [https://github.com/VinnyVanGogh/toml_cfg_tool/security/code-scanning/5](https://github.com/VinnyVanGogh/toml_cfg_tool/security/code-scanning/5)

To fix the problem, we need to ensure that the URL's hostname is correctly validated to prevent malicious URLs from passing the check. The best way to do this is to parse the URL and check that the hostname is exactly "github.com" or a subdomain of "github.com". This can be achieved by using the `urlparse` function to extract the hostname and then performing a more precise check.

1. Parse the URL using `urlparse`.
2. Extract the hostname from the parsed URL.
3. Check if the hostname is exactly "github.com" or ends with ".github.com".


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
