### PR TITLE
Fix code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/toml_cfg_tool/src/updates_cfg.py
+++ b/toml_cfg_tool/src/updates_cfg.py
@@ -6,7 +6,9 @@ from toml_cfg_tool.src.print_colors import print_two_colors
 
 def update_setup_cfg(file_path, repo_url, updates, dry_run=False, backup=False):
     
-    if "github.com" in repo_url:
+    from urllib.parse import urlparse
+    parsed_url = urlparse(repo_url)
+    if parsed_url.hostname and parsed_url.hostname.endswith("github.com"):
         config = configparser.ConfigParser()
         config.read(file_path)
         config['metadata']['url'] = repo_url


### PR DESCRIPTION
Fixes [https://github.com/VinnyVanGogh/toml_cfg_tool/security/code-scanning/3](https://github.com/VinnyVanGogh/toml_cfg_tool/security/code-scanning/3)

To fix the problem, we need to parse the URL and check the hostname to ensure it matches the expected domain. This can be done using the `urlparse` function from the `urllib.parse` module. Specifically, we will:
1. Parse the `repo_url` to extract the hostname.
2. Check if the hostname ends with `github.com` to ensure it is a valid GitHub URL.

This approach ensures that the URL is correctly validated and prevents malicious URLs from bypassing the check.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
