### PR TITLE
Fix code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/toml_cfg_tool/src/creation.py
+++ b/toml_cfg_tool/src/creation.py
@@ -42,7 +42,9 @@ def create_setup_cfg_template(file_path, dry_run=False):
         print_two_colors(ORANGE, BOLD, "Failed to create setup.cfg:", e)
 
     repo_url = get_github_repo_url()
-    if "github.com" in repo_url:
+    from urllib.parse import urlparse
+    parsed_url = urlparse(repo_url)
+    if parsed_url.hostname and parsed_url.hostname.endswith("github.com"):
         config = configparser.ConfigParser()
         config.read(file_path)
         config['metadata']['url'] = repo_url
@@ -64,7 +66,8 @@ def create_pyproject_toml_template(file_path, dry_run=False):
         print_two_colors(ORANGE, BOLD, "Failed to create pyproject.toml:", e)
    
     repo_url = get_github_repo_url()
-    if "github.com" in repo_url:
+    parsed_url = urlparse(repo_url)
+    if parsed_url.hostname and parsed_url.hostname.endswith("github.com"):
         config = toml.load(file_path)
         config['project']['urls']['Homepage'] = repo_url
         with open(file_path, 'w') as f:


### PR DESCRIPTION
Fixes [https://github.com/VinnyVanGogh/toml_cfg_tool/security/code-scanning/2](https://github.com/VinnyVanGogh/toml_cfg_tool/security/code-scanning/2)

To fix the problem, we should parse the URL and check the hostname to ensure it matches the expected domain. This can be done using the `urlparse` function from the `urllib.parse` module. Specifically, we should extract the hostname from the URL and verify that it ends with "github.com".

- Modify the code to use `urlparse` to parse the URL.
- Extract the hostname from the parsed URL.
- Check if the hostname ends with "github.com".


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
