### PR TITLE
Fix code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/toml_cfg_tool/src/creation.py
+++ b/toml_cfg_tool/src/creation.py
@@ -6,6 +6,7 @@ import toml
 import configparser
 import glob
 from pathlib import Path
+from urllib.parse import urlparse
 from toml_cfg_tool.src.config import template_text 
 from toml_cfg_tool.src.color_codes import BOLD, CYAN, LINK, ORANGE
 from toml_cfg_tool.src.print_colors import print_two_colors
@@ -42,7 +43,8 @@ def create_setup_cfg_template(file_path, dry_run=False):
         print_two_colors(ORANGE, BOLD, "Failed to create setup.cfg:", e)
 
     repo_url = get_github_repo_url()
-    if "github.com" in repo_url:
+    parsed_url = urlparse(repo_url)
+    if parsed_url.hostname and parsed_url.hostname.endswith("github.com"):
         config = configparser.ConfigParser()
         config.read(file_path)
         config['metadata']['url'] = repo_url
@@ -64,7 +66,8 @@ def create_pyproject_toml_template(file_path, dry_run=False):
         print_two_colors(ORANGE, BOLD, "Failed to create pyproject.toml:", e)
    
     repo_url = get_github_repo_url()
-    if "github.com" in repo_url:
+    parsed_url = urlparse(repo_url)
+    if parsed_url.hostname and parsed_url.hostname.endswith("github.com"):
         config = toml.load(file_path)
         config['project']['urls']['Homepage'] = repo_url
         with open(file_path, 'w') as f:


### PR DESCRIPTION
Fixes [https://github.com/VinnyVanGogh/toml_cfg_tool/security/code-scanning/1](https://github.com/VinnyVanGogh/toml_cfg_tool/security/code-scanning/1)

To fix the problem, we need to parse the URL and check the hostname to ensure it matches the expected domain. This can be done using the `urlparse` function from the `urllib.parse` module. Specifically, we will:
1. Parse the URL using `urlparse`.
2. Extract the hostname from the parsed URL.
3. Check if the hostname ends with "github.com" to ensure it is a valid GitHub URL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
